### PR TITLE
First Attempt for Test Cases

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,10 @@
 __pycache__/
 *.py[cod]
 
+#
+*.kate-swp
+*.~
+
 # C extensions
 *.so
 

--- a/docmanager/__init__.py
+++ b/docmanager/__init__.py
@@ -17,6 +17,7 @@
 # you may find current contact information at www.suse.com
 
 __author__="Rick Salevsky"
+__version__="3.0"
 
 import argparse
 from docmanager import action
@@ -39,15 +40,21 @@ class ArgParser:
     """Encapsulates arguments in ArgumentParser
     """
 
-    def __init__(self):
+    def __init__(self, args=None):
         """Initializes ArgParser class"""
+        self.__args=args
         self.__parser = argparse.ArgumentParser(prog="docmanager",
+                        # version=__version__,
                         description="Docmanager sets, gets, or analyzes meta-information for DocBook5 XML files.")
         self.add_arguments()
         self.parse_arguments()
 
     def add_arguments(self):
         """Adds arguments to ArgumentParser"""
+        self.__parser.add_argument('--version',
+                    action='version',
+                    version='%(prog)s ' + __version__
+                    )
         file_group = self.__parser.add_argument_group("Files")
         file_group.add_argument(
                     "-f",
@@ -92,7 +99,7 @@ class ArgParser:
 
     def parse_arguments(self):
         """Parses command line arguments"""
-        self.__parser.parse_args(namespace=self)
+        self.__parser.parse_args(args=self.__args, namespace=self)
         if self.set is not None:
             self.action="set"
             self.arguments=self.set

--- a/docmanager/xmlhandler.py
+++ b/docmanager/xmlhandler.py
@@ -37,7 +37,6 @@ class XmlHandler:
         #load the file and set a reference to the dm group
         self.__tree = etree.parse(filename, self.__xmlparser)
         self.__root = self.__tree.getroot()
-        self.indent=""
         self.__docmanager = self.__tree.find("//dm:docmanager", namespaces=self.__namespace)
         if self.__docmanager is None:
             self.create_group()
@@ -49,7 +48,6 @@ class XmlHandler:
         #search the info-element if not exists raise an error
         element = self.__tree.find("//d:info", namespaces=self.__namespace)
         if element is not None:
-            prev=element.getprevious()
             self.__docmanager = etree.SubElement(element,
                                                  "{{{dm}}}docmanager".format(**self.__namespace),
                                                  )
@@ -173,3 +171,26 @@ class XmlHandler:
         logmgr_flog()
 
         return self.__tree.docinfo.URL
+
+    @filename.setter
+    def filename(self, node):
+        raise ValueError("filename is only readable")
+    @filename.deleter
+    def filename(self):
+        raise ValueError("filename cannot be deleted")
+
+    @property
+    def tree(self):
+        """Return our parsed tree object
+
+        :return: tree object
+        :rtype:  lxml.etree._ElementTree
+        """
+        return self.__tree
+
+    @tree.setter
+    def tree(self, node):
+        raise ValueError("tree is only readable")
+    @tree.deleter
+    def tree(self):
+        raise ValueError("tree cannot be deleted")

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+addopts = -s -l -v
+norecursedirs = .git *.egg build env man __pycache__

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,0 +1,45 @@
+#
+# Copyright (c) 2015 SUSE Linux GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of version 3 of the GNU General Public License as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE about this file by physical or electronic mail,
+# you may find current contact information at www.suse.com
+
+import sys
+
+import pytest
+import py.path
+from lxml import etree
+
+testdir = py.path.local(py.path.local(__file__).dirname)
+
+# Add current directory; this makes it possible to import all
+# docmanager related files
+sys.path.append('.')
+
+# ------------------------------------------------------
+# Fixtures
+#
+
+@pytest.fixture(params=["test.01.xml"])
+def xmltmpfile(request, tmpdir):
+    """Copies XML file to temporary directory
+
+    :param pytest.fixture tmpdir: temporary directory fixture
+    :param request: XML filename as parameter
+    """
+    xmlfile=testdir / request.param
+    assert xmlfile.exists(), "temp XML file does not exist"
+    xmlfile.copy(tmpdir)
+    return tmpdir.listdir(sort=xmlfile.basename)[0]

--- a/test/test.01.xml
+++ b/test/test.01.xml
@@ -1,0 +1,18 @@
+<!DOCTYPE article [
+<!ENTITY foo "Hallo Welt">
+]>
+<article version="5.0" xml:lang="en"
+        xmlns:dm="urn:x-suse:ns:docmanager"
+        xmlns="http://docbook.org/ns/docbook"
+        xmlns:xlink="http://www.w3.org/1999/xlink">
+  <title>Example</title>
+  <info>
+    <author>
+        <personname>
+            <firstname>Manuel</firstname>
+            <surname>Schnitzer</surname>
+        </personname>
+    </author>
+  </info>
+  <para>Bla and &foo;</para>
+</article>

--- a/test/test_001.py
+++ b/test/test_001.py
@@ -1,9 +1,0 @@
-#!/usr/bin/python3
-
-def test_true():
-    assert True
-
-def test_hallo(tmpdir):
-    a = "Hallo"
-    print("tempdir=", tmpdir)
-    assert a == "Hallo"

--- a/test/test_version.py
+++ b/test/test_version.py
@@ -1,0 +1,20 @@
+#!/usr/bin/python3
+
+import sys
+import pytest
+
+from docmanager import __version__
+from docmanager import ArgParser
+
+
+def test_version():
+    """Check if version is available and set"""
+    assert __version__
+
+def test_version_from_cli(capsys):
+    """Checks if option --version creates a correct version"""
+    # Source: http://pytest.org/latest/capture.html?highlight=capsys#accessing-captured-output-from-a-test-function
+    with pytest.raises(SystemExit):
+        parser = ArgParser(["testdm", "--version"])
+        out, err = capsys.readouterr()
+        assert err.split()[-1] == __version__

--- a/test/test_xml.py
+++ b/test/test_xml.py
@@ -1,0 +1,76 @@
+#!/usr/bin/python3
+
+import os.path
+import sys
+from io import StringIO
+import pytest
+import py.path
+from lxml import etree
+
+from docmanager.xmlhandler import XmlHandler
+
+# os.path.relpath(os.path.abspath("test"))
+testdir = py.path.local("test")
+
+NS = {
+        "d":"http://docbook.org/ns/docbook",
+        "dm":"urn:x-suse:ns:docmanager"
+     }
+
+def test_XmlHandler_filename(xmltmpfile):
+    """Checks filename property XmlHandler class
+
+    :param py.path.local xmltmpfile: Fixture, pointing to a temporary XML file
+    """
+    xml = XmlHandler(xmltmpfile.strpath)
+    assert xml, "No XmlHandler could be instantiated"
+    assert xml.filename == xmltmpfile.strpath
+
+
+def test_XmlHandler_tree(xmltmpfile):
+    """Checks tree property of XmlHandler class
+
+    :param py.path.local xmltmpfile: Fixture, pointing to a temporary XML file
+    """
+    xml = XmlHandler(xmltmpfile.strpath)
+    assert xml, "No XmlHandler could be instantiated"
+    assert xml.tree
+
+
+def test_XmlHandler_docmanager(xmltmpfile):
+    """Checks if docmanager element is available
+
+    :param py.path.local xmltmpfile: Fixture, pointing to a temporary XML file
+    """
+    xml = XmlHandler(xmltmpfile.strpath)
+    assert xml, "No XmlHandler could be instantiated"
+    tree = xml.tree
+    tree.find("//dm:docmanager", namespaces=NS)
+    assert tree, "No docmanager element available"
+
+
+def test_XmlHandler_set(xmltmpfile):
+    """Checks if docmanager element is available
+
+    :param py.path.local xmltmpfile: Fixture, pointing to a temporary XML file
+    """
+    xml = XmlHandler(xmltmpfile.strpath)
+    assert xml, "No XmlHandler could be instantiated"
+    xml.set("foo", "2")
+    dm = xml.tree.find("//dm:docmanager", namespaces=NS)
+    assert len(dm), "expected child elements in docmanager"
+
+    # Let's test the written XML file
+    tree = etree.parse(xmltmpfile.strpath)
+    dm = tree.find("//dm:docmanager", namespaces=NS)
+    assert len(dm), "expected child elements in docmanager"
+
+
+def test_XmlHandler_is_set(xmltmpfile):
+    """Checks XmlHandler.is_set method
+
+    :param py.path.local xmltmpfile: Fixture, pointing to a temporary XML file
+    """
+    xml = XmlHandler(xmltmpfile.strpath)
+    assert xml, "No XmlHandler could be instantiated"
+    assert not xml.is_set("foo", "nix"), "Tag 'foo' shouldn't be here"


### PR DESCRIPTION
- Implemented `--version`
  - Check if `__version__` is available and set
  - Test --version from command line
  - Used capsys fixture
- Added preliminary `conftest.py` for pytest, adding `xmltmpfile()` fixture
- Added first attempt of `pytest.ini`
  This allows running `py.test` without having troubles with Python's virtual environment
- Extended constructor of `ArgParser` to allow passing your own arguments. By default its `args=None`, which is an indicator to use `sys.argv`
- Test `XMLHandler.filename` property
  - Added tree property in `XmlHandler`
  - Used `py.path.local` extensively
  - Added example test file `test.01.xml`
  - Removed obsolete `self.indent=""` and `prev=element.getprevious()` in XmlHandler class
- Tested XmlHandler class
  - `tree` property
  - Checking for `docmanager` element
  - `set()` and `is_set()` method
- Added setter/getter property for `filename` and `tree` properties
- Ignored `*kate-swp` files in `.gitignore`
