### PR TITLE
Try to fix OBS error for openSUSE 13.2

### DIFF
--- a/test/test_multiple_files.py
+++ b/test/test_multiple_files.py
@@ -18,6 +18,24 @@ def repeat(iterable, n=1):
             yield i
 
 
+
+
+def compare_pytest_version(minimum):
+    """Compares existing pytest version with required
+
+    :param list minimum: Minimum version in the form of
+                         [major, minor, release ]
+    :return: condition met (True) or not (False)
+    :rtype: bool
+    """
+    pytestversion = [ int(n) for n in pytest.__version__.split('.')]
+    minimum = list(minimum)
+    return minimum <= pytestversion
+
+
+
+@pytest.mark.skipif(compare_pytest_version((2,6,4)),
+                    reason="Need 2.6.4 to execute this test")
 @pytest.mark.parametrize("props,xmlset,expected", [
   (["status"], ["test-dm-status-1.xml", "test-dm-status-2.xml"], ["a", "b"]),
   (["foo"], ["test-dm-status-1.xml", "test-dm-status-2.xml"],    []),


### PR DESCRIPTION
- Added compare_pytest_version() function
- Marked test with pytest.mark.skipif decorator
