### PR TITLE
New implementation of root_sourceline

### DIFF
--- a/docmanager/xmlhandler.py
+++ b/docmanager/xmlhandler.py
@@ -22,7 +22,7 @@ import sys
 from docmanager.core import DefaultDocManagerProperties, \
     NS, ReturnCodes, VALIDROOTS
 from docmanager.logmanager import log, logmgr_flog
-from docmanager.xmlutil import root_sourceline, \
+from docmanager.xmlutil import findprolog, \
     replaceinstream, ensurefileobj, \
     preserve_entities, recover_entities
 from io import StringIO
@@ -42,7 +42,7 @@ class XmlHandler(object):
 
         self._filename = filename
         self._buffer = ensurefileobj(filename)
-        prolog = root_sourceline(self._buffer)
+        prolog = findprolog(self._buffer)
         self._offset, self._header = prolog['offset'], prolog['header']
 
         # Replace any entities

--- a/docmanager/xmlutil.py
+++ b/docmanager/xmlutil.py
@@ -25,7 +25,6 @@ import re
 import os
 import sys
 
-from lxml import etree
 import xml.sax
 from xml.sax._exceptions import SAXParseException
 
@@ -194,9 +193,6 @@ class Handler(xml.sax.handler.ContentHandler):
     def setDocumentLocator(self, loc):
         self.loc = loc
 
-    def startDocument(self):
-        current = self.locstm.where(self.loc)
-
     def startElement(self, name, attrs):
         ctxlen = len(self.context)
         if ctxlen < 2:
@@ -207,8 +203,6 @@ class Handler(xml.sax.handler.ContentHandler):
             self.context.append(["%s" % name, p])
 
     def endElement(self, name):
-        ctxlen = len(self.context)
-
         eline = self.loc.getLineNumber()
         ecol = self.loc.getColumnNumber()
         last = self.locstm.where(self.loc)
@@ -235,11 +229,11 @@ def findprolog(source, maxsize=5000):
     context = []
 
     try:
-        buffer = ensurefileobj(source)
+        buf = ensurefileobj(source)
         # We read in maxsize and save it
-        XML = buffer.read(maxsize)
-        buffer.seek(0)
-        locstm = LocatingWrapper(buffer)
+        XML = buf.read(maxsize)
+        buf.seek(0)
+        locstm = LocatingWrapper(buf)
         parser = xml.sax.make_parser()
 
         # Disable certain features
@@ -249,7 +243,7 @@ def findprolog(source, maxsize=5000):
 
         parser.setContentHandler(Handler(context, locstm))
         parser.parse(locstm)
-    except SAXParseException as err:
+    except SAXParseException:
         raise SystemExit(ReturnCodes.E_XML_PARSE_ERROR)
 
     first = context[0]

--- a/docmanager/xmlutil.py
+++ b/docmanager/xmlutil.py
@@ -16,52 +16,24 @@
 # To contact SUSE about this file by physical or electronic mail,
 # you may find current contact information at www.suse.com
 
+import copy
+from collections import namedtuple
+from docmanager.core import ReturnCodes
 from io import StringIO
+from itertools import accumulate
 import re
 import os
 import sys
 
 from lxml import etree
-
-# All elements which are valid as root (from 5.1CR3)
-VALIDROOTS = ('abstract', 'address', 'annotation', 'audiodata',
-              'audioobject', 'bibliodiv', 'bibliography', 'bibliolist',
-              'bibliolist', 'blockquote', 'book', 'calloutlist',
-              'calloutlist', 'caption', 'caution', 'classsynopsis',
-              'classsynopsisinfo', 'cmdsynopsis', 'cmdsynopsis', 'components',
-              'constraintdef', 'constructorsynopsis', 'destructorsynopsis',
-              'epigraph', 'equation', 'equation', 'example', 'fieldsynopsis',
-              'figure', 'formalpara', 'funcsynopsis', 'funcsynopsisinfo',
-              'glossary', 'glossary', 'glossdiv', 'glosslist', 'glosslist',
-              'imagedata', 'imageobject', 'imageobjectco', 'imageobjectco',
-              'important', 'index', 'indexdiv', 'informalequation',
-              'informalequation', 'informalexample', 'informalfigure',
-              'informaltable', 'inlinemediaobject', 'itemizedlist',
-              'legalnotice', 'literallayout', 'mediaobject', 'methodsynopsis',
-              'msg', 'msgexplan', 'msgmain', 'msgrel', 'msgset', 'msgsub',
-              'note', 'orderedlist', 'para', 'part', 'partintro',
-              'personblurb', 'procedure', 'productionset', 'programlisting',
-              'programlistingco', 'programlistingco', 'qandadiv',
-              'qandaentry', 'qandaset', 'qandaset', 'refentry',
-              'refsect1', 'refsect2', 'refsect3',
-              'refsection', 'refsynopsisdiv', 'revhistory', 'screen',
-              'screenco', 'screenco', 'screenshot',
-              'sect1', 'sect2', 'sect3', 'sect4', 'sect5',
-              'section', 'segmentedlist', 'set', 'set', 'setindex', 'sidebar',
-              'simpara', 'simplelist', 'simplesect',
-              'step', 'stepalternatives', 'synopsis',
-              'table', 'task', 'taskprerequisites', 'taskrelated',
-              'tasksummary', 'textdata', 'textobject', 'tip', 'toc', 'tocdiv',
-              'topic', 'variablelist', 'videodata', 'videoobject', 'warning'
-             )
-
+import xml.sax
+from xml.sax._exceptions import SAXParseException
 
 # -------------------------------------------------------------------
 # Regular Expressions
 
 ENTS = re.compile("(&([\w_.]+);)")
 STEN = re.compile("(\[\[\[(\#?[\w_.]+)\]\]\])")
-
 
 
 def ent2txt(match, start="[[[", end="]]]"):
@@ -161,17 +133,16 @@ def ensurefileobj(source):
 
     # StringIO support:
     if hasattr(source, 'getvalue') and hasattr(source, 'tell'):
-        # we do nothing
-        pass
+        # we return a copy
+        return copy.copy(source)
     elif isinstance(source, (str, bytes)):
         if isXML(source):
-            source = StringIO(source)
+            return StringIO(source)
         else:
             # source isn't a file-like object nor starts with XML structure
             # so it has to be a filename
-            source = StringIO(open(source, 'r').read())
+            return StringIO(open(source, 'r').read())
     # TODO: Check if source is an URL; should we allow this?
-    return source
 
 
 # -------------------------------------------------------------------
@@ -190,121 +161,111 @@ def localname(tag):
     else:
         return tag
 
-def compilestarttag():
-    """Compile a regular expression for start tags like <article> or
-       <d:book> with or without any  attributes
-
-       :return: a pattern object
-       :rtype: _sre.SRE_Pattern
-    """
-# Taken from the xmllib.py
-# http://code.metager.de/source/xref/python/jython/lib-python/2.7/xmllib.py
-    _S = '[ \t\r\n]+'                       # white space
-    _opS = '[ \t\r\n]*'                     # optional white space
-    _Name = '[a-zA-Z_:][-a-zA-Z0-9._:]*'    # valid XML name
-    _QStr = "(?:'[^']*'|\"[^\"]*\")"        # quoted XML string
-    attrfind = re.compile(
-        _S + '(?P<name>' + _Name + ')'
-        '(' + _opS + '=' + _opS +
-        '(?P<value>' + _QStr + '|[-a-zA-Z0-9.:+*%?!\(\)_#=~]+))?')
-    starttagend = re.compile(_opS + '(?P<slash>/?)>')
-    return re.compile('<(?P<tagname>' + _Name + ')'
-                      '(?P<attrs>(?:' + attrfind.pattern + ')*)' +
-                      starttagend.pattern)
 
 
-def root_sourceline(source, resolver=None):
-    """Returns a dictionary with essential information about the root element
+# -------------
+
+class LocatingWrapper(object):
+    def __init__(self, f):
+        self.f = f
+        self.offset = [0]
+        self.curoffs = 0
+
+    def read(self, *a):
+        data = self.f.read(*a)
+        self.offset.extend(accumulate(len(m)+1 for m in data.split('\n')))
+        return data
+
+    def where(self, loc):
+        return self.offset[loc.getLineNumber() - 1] + loc.getColumnNumber()
+
+    def close(self):
+        self.f.close()
+
+
+class Handler(xml.sax.handler.ContentHandler):
+    def __init__( self, context, locator):
+        # handler.ContentHandler.__init__( self )
+        super().__init__()
+        self.context = context
+        self.locstm = locator
+        self.pos = namedtuple('Position', ['line', 'col', 'offset'])
+
+    def setDocumentLocator(self, loc):
+        self.loc = loc
+
+    def startDocument(self):
+        current = self.locstm.where(self.loc)
+
+    def startElement(self, name, attrs):
+        ctxlen = len(self.context)
+        if ctxlen < 2:
+            current = self.locstm.where(self.loc)
+            p = self.pos(self.loc.getLineNumber(), \
+                         self.loc.getColumnNumber(), \
+                         current)
+            self.context.append(["%s" % name, p])
+
+    def endElement(self, name):
+        ctxlen = len(self.context)
+
+        eline = self.loc.getLineNumber()
+        ecol = self.loc.getColumnNumber()
+        last = self.locstm.where(self.loc)
+        p = self.pos(line=eline, col=ecol, offset=last)
+        self.context.append(["/%s" % name, p])
+
+
+def findprolog(source, maxsize=5000):
+    """Returns a dictionary with essential information about the prolog
 
     :param source:
-    :type source: filename, file object, or file-like object
+    :type source: source, file object, or file-like object
                   expected to be well-formed
-    :param etree.Resolver resolver: custom resolver
-    :return: line number, column
-    :rtype: tuple
+    :param int maxize: Maximum size of bytes to read into XML buffer
+    :return: { 'header': '...', # str everything before the start tag
+               'root':   '...', # str: start tag from '<' til '>'
+               'offset:  1,     # Integer
+             }
+    :rtype: dict
     """
-    # See https://gist.github.com/tomschr/6ecaaf69231dfbc9517a
-    # for an alternative implementation with SaX
-
     result = {}
-    parser = etree.XMLParser(remove_blank_text=False,
-                             resolve_entities=False,
-                             dtd_validation=False,
-                             load_dtd=False)
-    if resolver is not None:
-        parser.resolvers.add(resolver)
 
-    buffer = ensurefileobj(source)
-    tree = etree.parse(buffer, parser)
-    root = tree.getroot()
+    # context is used to save everything
+    context = []
 
-    # Get first an "approximation" of where we could find it
-    maxsourceline = root.sourceline
+    try:
+        buffer = ensurefileobj(source)
+        # We read in maxsize and save it
+        XML = buffer.read(maxsize)
+        buffer.seek(0)
+        locstm = LocatingWrapper(buffer)
+        parser = xml.sax.make_parser()
 
-    # HACK: lxml's .sourceline returns only the _end_ of the start tag.
-    # For example:
-    #
-    # 1| <?xml version="1.0"?>
-    # 2| <!DOCTYPE article
-    # 3| [ ...
-    # 4| ]>
-    # 5| <article version="5.0" xml:lang="en"
-    # 6|          xmlns:dm="urn:x-suse:ns:docmanager"
-    # 7|          xmlns="http://docbook.org/ns/docbook"
-    # 8|          xmlns:xlink="http://www.w3.org/1999/xlink">
-    #
-    # In the above example, we need line 5, but .sourceline returns line 8
-    # which is "wrong". 
-    # Therefor we need to go back from line 8 until we find the start-tag
-    #
-    # See thread in
-    # https://mailman-mail5.webfaction.com/pipermail/lxml/2015-May/007518.html
+        # Disable certain features
+        parser.setFeature(xml.sax.handler.feature_validation, False)
+        parser.setFeature(xml.sax.handler.feature_external_ges, False)
+        parser.setFeature(xml.sax.handler.feature_external_pes, False)
 
-    # Find any start-tag which match this regex:
+        parser.setContentHandler(Handler(context, locstm))
+        parser.parse(locstm)
+    except SAXParseException as err:
+        raise SystemExit(ReturnCodes.E_XML_PARSE_ERROR)
 
-    prefix = root.prefix if root.prefix else ""
-    starttag = compilestarttag()
+    first = context[0]
+    soffset = first[1].offset
+    doctype = XML[:soffset]
 
-    # Read lines until maxsourceline is reached
-    header = [next(buffer) for _ in range(maxsourceline)]
-
-    # Try to first check, if start tag appears on one line
-    i = maxsourceline - 1
-    match = starttag.search(header[i])
-    offset = 0
-    
-    if not match:
-        # We need to search for the beginning of the start tag
-        ll = []
-        # Iterate in reverse order to find a match for our start-tag
-        for i, line in enumerate(reversed(header)):
-            ll.insert(0, line)
-            match = starttag.search("".join(ll))
-            
-            if match:
-                break
-        
-        length = len("".join(ll))
-        length -= match.span()[0]
-        offset = len("".join(header))-length
+    if context[1][0][0] == '/':
+        last = context[-1]
     else:
-        offset = match.span()[0]
-        offset += len("".join(header[:i]))
+        last = context[1]
 
-    # Variable 'i' contains now the (line) offset where you can find
-    # the start tag inside the header
-    #
-    # offset is the number of character before the start tag
-    #offset += len("".join(header[:i]))
-    # print("Match obj:", match, match.groupdict() )
+    eoffset = last[1].offset
+    starttag = XML[soffset:eoffset].rstrip(' ')
 
-    # The character offset
-    result['offset'] = offset
 
-    # span is the character offset and can be used to cut off the start tag
-    # for example: "".join(result['header'])[slice(*result['span'])]
-    s = match.span()
-    result['header'] = "".join(header)[:offset]
-    result['root'] = "".join(header)[offset:]
-    
+    result['header'] = doctype
+    result['root'] = starttag
+    result['offset'] = len(doctype)
     return result

--- a/test/test_docmanager_brokenxml.py
+++ b/test/test_docmanager_brokenxml.py
@@ -2,7 +2,8 @@
 
 import pytest
 from docmanager.xmlhandler import XmlHandler
-from lxml.etree import XMLSyntaxError
+# from lxml.etree import XMLSyntaxError
+from xml.sax._exceptions import SAXParseException
 
 def test_brokenxml(tmp_broken_xml):
     """Checks the behavior of the XML handler if an exception will be
@@ -11,5 +12,5 @@ def test_brokenxml(tmp_broken_xml):
     :param py.path.local tmp_broken_xml: Fixture, pointing to a temporary
                                          XML file
     """
-    with pytest.raises(XMLSyntaxError):
+    with pytest.raises(SystemExit) as err:
         handler = XmlHandler(tmp_broken_xml.strpath)

--- a/test/test_docmanager_exitcodes.py
+++ b/test/test_docmanager_exitcodes.py
@@ -4,6 +4,7 @@ import pytest
 from docmanager import parsecli
 from docmanager.action import Actions
 from docmanager.core import ReturnCodes
+from xml.sax._exceptions import SAXParseException
 
 def test_exitcodes_0(tmp_broken_xml):
     """ call docmanager without params """

--- a/test/test_prolog.py
+++ b/test/test_prolog.py
@@ -2,23 +2,32 @@
 
 import pytest
 import re
-from docmanager.xmlutil import compilestarttag, root_sourceline
+from docmanager.xmlutil import findprolog
 from io import StringIO
 
-IDS =['normal', 'with_cr', 'with_systemid', 'complete', 'with_ns', 'without_linebreak', 'without_linebreak_2', 'everything_in_one_line']
+IDS =['normal',
+      #'with_cr',
+      'with_systemid', 'complete', 'with_ns',
+      'without_linebreak', 'without_linebreak_2', 'everything_in_one_line']
 
 doctypeslist = [# xml,expected
   # 0
   ("\n<!DOCTYPE book>\n<book/>",
-    {'root': '<book/>', 'offset': 17, 'header': '\n<!DOCTYPE book>\n'}
+    {'root': '<book/>',
+     'offset': 17,
+     'header': '\n<!DOCTYPE book>\n'}
   ),
   # 1
-  ("\n<!DOCTYPE  \tbook\n\n>\n\n<book\n/>",
-    {'root': '<book\n/>', 'offset': 22, 'header': '\n<!DOCTYPE  \tbook\n\n>\n\n'}
-  ),
+#  ("\n<!DOCTYPE  \tbook\n\n>\n\n<book\n/>",
+#    {'root': '<book\n/>',
+#     'offset': 22,
+#     'header': '\n<!DOCTYPE  \tbook\n\n>\n\n'}
+#  ),
   # 2
   ("""\n<!DOCTYPE book SYSTEM "book.dtd"><book/>""",
-    {'root': '<book/>', 'offset': 34, 'header': '\n<!DOCTYPE book SYSTEM "book.dtd">'}
+    {'root': '<book/>',
+     'offset': 34,
+     'header': '\n<!DOCTYPE book SYSTEM "book.dtd">'}
   ),
   ## 3
   ("""<!DOCTYPE article [
@@ -63,7 +72,9 @@ doctypeslist = [# xml,expected
                 'root': '<article id="bla">\n'}),
   ## 7
   ("""<!DOCTYPE article []><article/>""",
-   {'header': '<!DOCTYPE article []>', 'offset': 21, 'root': '<article/>'})
+   {'header': '<!DOCTYPE article []>',
+    'offset': 21,
+    'root': '<article/>'})
 ]
 
 @pytest.mark.parametrize("xml,expected",
@@ -74,7 +85,7 @@ def test_prolog_with_stringio(xml, expected):
     """Checks if parsing of prolog works with StringIO
     """
     source = StringIO(xml)
-    result = root_sourceline(source)
+    result = findprolog(source)
     assert result == expected
 
 
@@ -85,7 +96,7 @@ def test_prolog_with_stringio(xml, expected):
 def test_prolog_with_string(xml, expected):
     """Checks if parsing of prolog works with normal strings
     """
-    result = root_sourceline(xml)
+    result = findprolog(xml)
     assert result == expected
 
 
@@ -99,31 +110,6 @@ def test_prolog_with_filename(xml, expected, tmpdir):
     fh.write(xml)
     fh.close()
     
-    result = root_sourceline(tmp)
+    result = findprolog(tmp)
     assert result == expected
 
-
-#################################################################################
-
-content_compilestarttag = [
-    ## 1
-    (
-        """<!DOCTYPE article [
-]>
-
-<article xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink"
-    version="5.0" xml:lang="en">""",
-        (24, 146)
-    ),
-    ## 2
-    (
-        """<!DOCTYPE article []><article></article>""",
-        (21, 30)
-    )
-]
-@pytest.mark.parametrize("content,expected",
-                         content_compilestarttag)
-def test_compilestarttag(content, expected):
-    tag = compilestarttag()
-    result = tag.search(content)
-    assert result.span() == expected

--- a/test/test_prolog.py
+++ b/test/test_prolog.py
@@ -5,8 +5,7 @@ import re
 from docmanager.xmlutil import findprolog
 from io import StringIO
 
-IDS =['normal',
-      #'with_cr',
+IDS =['normal', 'with_cr',
       'with_systemid', 'complete', 'with_ns',
       'without_linebreak', 'without_linebreak_2', 'everything_in_one_line']
 
@@ -18,11 +17,11 @@ doctypeslist = [# xml,expected
      'header': '\n<!DOCTYPE book>\n'}
   ),
   # 1
-#  ("\n<!DOCTYPE  \tbook\n\n>\n\n<book\n/>",
-#    {'root': '<book\n/>',
-#     'offset': 22,
-#     'header': '\n<!DOCTYPE  \tbook\n\n>\n\n'}
-#  ),
+  ("\n<!DOCTYPE  \tbook\n\n>\n\n<book\n/>",
+    {'root': '<book\n/>',
+     'offset': 22,
+     'header': '\n<!DOCTYPE  \tbook\n\n>\n\n'}
+  ),
   # 2
   ("""\n<!DOCTYPE book SYSTEM "book.dtd"><book/>""",
     {'root': '<book/>',


### PR DESCRIPTION
xmlutil.py:
- Removed VALIDROOTS
- Removed obsolete compilestarttag() function
- Renamed root_sourceline -> findprolog;
- Reimplemented findprolog with xml.sax.handler.ContentHandler
  and Locator

xmlhandler.py:
- Used corrected function findprolog
- Fixed testcases
  <a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/openSUSE/docmanager/pull/32%23issuecomment-108976888%22%2C%20%22https%3A//github.com/openSUSE/docmanager/pull/32%23issuecomment-108981432%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/openSUSE/docmanager/pull/32%23issuecomment-108976888%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%5B%21%5BCode%20Health%5D%28https%3A//landscape.io/badge/181569/landscape.svg%3Fstyle%3Dflat%29%5D%28https%3A//landscape.io/diff/169808%29%5CnRepository%20health%20decreased%20by%201.00%25%20when%20pulling%20%2A%2A%5Bd9822ab%5D%28https%3A//github.com/openSUSE/docmanager/commit/d9822abe2c93fb6e2c6d41fa0172d5664ec732be%29%20on%20feature/starttagfix-a%2A%2A%20into%20%2A%2A%5B290ff3e%5D%28https%3A//github.com/openSUSE/docmanager/commit/290ff3eb3dec27e674135e63bfbd6e51d88b3057%29%20on%20develop%2A%2A.%5Cn%5Cn%20%2A%20%5B6%20new%20problems%20were%20found%5D%28https%3A//landscape.io/diff/169808%29%20%28including%201%20error%20and%205%20code%20smells%29.%5Cn%20%2A%20%5B4%20problems%20were%20fixed%5D%28https%3A//landscape.io/diff/169808/fixed%29%20%28including%200%20errors%20and%203%20code%20smells%29.%22%2C%20%22created_at%22%3A%20%222015-06-04T17%3A08%3A19Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/10010231%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/landscape-bot%22%7D%7D%2C%20%7B%22body%22%3A%20%22%5B%21%5BCode%20Health%5D%28https%3A//landscape.io/badge/181580/landscape.svg%3Fstyle%3Dflat%29%5D%28https%3A//landscape.io/diff/169835%29%5CnRepository%20health%20increased%20by%200.40%25%20when%20pulling%20%2A%2A%5B7fafc98%5D%28https%3A//github.com/openSUSE/docmanager/commit/7fafc987c093b54f11fff72eb1a9aba9f6535213%29%20on%20feature/starttagfix-a%2A%2A%20into%20%2A%2A%5B290ff3e%5D%28https%3A//github.com/openSUSE/docmanager/commit/290ff3eb3dec27e674135e63bfbd6e51d88b3057%29%20on%20develop%2A%2A.%5Cn%5Cn%20%2A%20%5B1%20new%20problem%20was%20found%5D%28https%3A//landscape.io/diff/169835%29%20%28including%201%20error%20and%200%20code%20smells%29.%5Cn%20%2A%20%5B4%20problems%20were%20fixed%5D%28https%3A//landscape.io/diff/169835/fixed%29%20%28including%200%20errors%20and%203%20code%20smells%29.%22%2C%20%22created_at%22%3A%20%222015-06-04T17%3A22%3A49Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/10010231%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/landscape-bot%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%7D'></a>
  <a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/openSUSE/docmanager/pull/32#issuecomment-108976888'>General Comment</a></b>
- <a href='https://github.com/landscape-bot'><img border=0 src='https://avatars.githubusercontent.com/u/10010231?v=3' height=16 width=16'></a> [![Code Health](https://landscape.io/badge/181569/landscape.svg?style=flat)](https://landscape.io/diff/169808)
  Repository health decreased by 1.00% when pulling **[d9822ab](https://github.com/openSUSE/docmanager/commit/d9822abe2c93fb6e2c6d41fa0172d5664ec732be) on feature/starttagfix-a** into **[290ff3e](https://github.com/openSUSE/docmanager/commit/290ff3eb3dec27e674135e63bfbd6e51d88b3057) on develop**.
- [6 new problems were found](https://landscape.io/diff/169808) (including 1 error and 5 code smells).
- [4 problems were fixed](https://landscape.io/diff/169808/fixed) (including 0 errors and 3 code smells).
- <a href='https://github.com/landscape-bot'><img border=0 src='https://avatars.githubusercontent.com/u/10010231?v=3' height=16 width=16'></a> [![Code Health](https://landscape.io/badge/181580/landscape.svg?style=flat)](https://landscape.io/diff/169835)
  Repository health increased by 0.40% when pulling **[7fafc98](https://github.com/openSUSE/docmanager/commit/7fafc987c093b54f11fff72eb1a9aba9f6535213) on feature/starttagfix-a** into **[290ff3e](https://github.com/openSUSE/docmanager/commit/290ff3eb3dec27e674135e63bfbd6e51d88b3057) on develop**.
- [1 new problem was found](https://landscape.io/diff/169835) (including 1 error and 0 code smells).
- [4 problems were fixed](https://landscape.io/diff/169835/fixed) (including 0 errors and 3 code smells).

<a href='https://www.codereviewhub.com/openSUSE/docmanager/pull/32?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/openSUSE/docmanager/pull/32?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/openSUSE/docmanager/pull/32'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
