### PR TITLE
Fixed style and code isses from Landscape.io

### DIFF
--- a/docmanager/__init__.py
+++ b/docmanager/__init__.py
@@ -44,11 +44,11 @@ def main(cliargs=None):
 
         renderer(res)
     except PermissionError as err: # noqa
-        log.error("{} on file {!r}.".format(err.args[1], err.filename))
+        log.error("%s on file %r.", err.args[1], err.filename)
         sys.exit(ReturnCodes.E_PERMISSION_DENIED)
     except ValueError as err:
         log.error(err)
         sys.exit(ReturnCodes.E_INVALID_XML_DOCUMENT)
     except FileNotFoundError as err: # noqa
-        log.error("Could not find file '{}'.".format(err.filename))
+        log.error("Could not find file %r.", err.filename)
         sys.exit(ReturnCodes.E_FILE_NOT_FOUND)

--- a/docmanager/__init__.py
+++ b/docmanager/__init__.py
@@ -41,7 +41,7 @@ def main(cliargs=None):
             renderer = getrenderer('default')
         else:
             renderer = getrenderer(a.args.format)
-        
+
         renderer(res)
     except PermissionError as err: # noqa
         log.error("{} on file {!r}.".format(err.args[1], err.filename))

--- a/docmanager/action.py
+++ b/docmanager/action.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2014-2015 SUSE Linux GmbH
+# Copyright (c) 2015 SUSE Linux GmbH
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of version 3 of the GNU General Public License as
@@ -67,7 +67,7 @@ class Actions(object):
         invalidFiles = 0
 
         # append bugtracker properties if needed
-        if self.__args.with_bugtracker == True:
+        if self.__args.with_bugtracker:
             for p in BugtrackerElementList:
                 props.append(p)
 
@@ -80,7 +80,7 @@ class Actions(object):
 
         # iter through all xml handlers and init its properties
         for xh in self.__xml:
-            if xh.invalidXML == False:
+            if not xh.invalidXML:
                 validFiles += 1
 
                 log.debug("Trying to initialize the predefined DocManager properties for '{}'.".format(xh.filename))
@@ -138,7 +138,6 @@ class Actions(object):
             else:
                 validFiles += 1
 
-
         # split key and value
         args = [ i.split("=") for i in arguments]
 
@@ -153,7 +152,7 @@ class Actions(object):
                 for f in self.__files:
                     if not handlers[f].invalidXML:
                         log.debug("[{}] Trying to set value for property '{}' to '{}'.".format(f, key, value))
-                        if self.__args.bugtracker == True:
+                        if self.__args.bugtracker:
                             handlers[f].set({"bugtracker/" + key: value})
                         else:
                             handlers[f].set({key: value})

--- a/docmanager/action.py
+++ b/docmanager/action.py
@@ -123,8 +123,8 @@ class Actions(object):
                 invalidfiles += 1
                 print("[{}] Initialized default properties for '{}{}'. ".format(\
                     red("failed"),
-                    xh.filename),
-                    red(xh.xmlLogErrorString))
+                    xh.filename,
+                    red(xh.xmlLogErrorString)))
 
         print("\nInitialized successfully {} files. {} files failed.".format(\
               green(validfiles), red(invalidfiles)))

--- a/docmanager/action.py
+++ b/docmanager/action.py
@@ -121,7 +121,7 @@ class Actions(object):
                 xh.write()
             else:
                 invalidfiles += 1
-                print("[{}] Initialized default properties for '{}{}'. ".format(\
+                print("[{}] Initialized default properties for {!r}: {}. ".format(\
                     red("failed"),
                     xh.filename,
                     red(xh.xmlLogErrorString)))

--- a/docmanager/cli.py
+++ b/docmanager/cli.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2014-2015 SUSE Linux GmbH
+# Copyright (c) 2015 SUSE Linux GmbH
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of version 3 of the GNU General Public License as
@@ -300,7 +300,7 @@ def parsecli(cliargs=None):
     return args
 
 
-def show_langlist(columns=None, *, padding=2):
+def show_langlist(columns=None, padding=2):
     """Prints all supported languages
 
     :param int columns: Maximum number of characters in a column;

--- a/docmanager/core.py
+++ b/docmanager/core.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2014-2015 SUSE Linux GmbH
+# Copyright (c) 2015 SUSE Linux GmbH
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of version 3 of the GNU General Public License as

--- a/docmanager/core.py
+++ b/docmanager/core.py
@@ -40,6 +40,8 @@ BugtrackerElementList = (
     "bugtracker/version"
 )
 
+STATUSFLAGS = ('editing', 'edited', 'proofing', 'proofed', 'comment', 'ready')
+
 class ReturnCodes(object):
     E_OK = 0
     E_FILE_NOT_FOUND = 1

--- a/docmanager/display.py
+++ b/docmanager/display.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2014-2015 SUSE Linux GmbH
+# Copyright (c) 2015 SUSE Linux GmbH
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of version 3 of the GNU General Public License as
@@ -21,7 +21,7 @@ from collections import OrderedDict
 from lxml import etree
 from prettytable import PrettyTable
 
-def textrenderer(data, **kwargs):
+def textrenderer(data, **kwargs): # pylint: disable=unused-argument
     """Normal text output
 
     :param list data: Filename with properties
@@ -48,7 +48,7 @@ def textrenderer(data, **kwargs):
             print("{} -> {}".format(d[0], props))
 
 
-def tablerenderer(data, **kwargs):
+def tablerenderer(data, **kwargs): # pylint: disable=unused-argument
     """Output as table
 
     :param list data: Filename with properties
@@ -68,7 +68,7 @@ def tablerenderer(data, **kwargs):
             t = PrettyTable(["Property", "Value"])
             t.align["Property"] = "l" # left align
             t.align["Value"] = "l" # left align
-            
+
             for prop in i[1]:
                 value = i[1][prop]
                 t.add_row([prop, value])
@@ -80,7 +80,7 @@ def tablerenderer(data, **kwargs):
         index += 1
 
 
-def jsonrenderer(data, **kwargs):
+def jsonrenderer(data, **kwargs): # pylint: disable=unused-argument
     """Output as JSON
 
     :param list data: Filename with properties
@@ -97,7 +97,7 @@ def jsonrenderer(data, **kwargs):
     print(json.dumps(json_out))
 
 
-def xmlrenderer(data, **kwargs):
+def xmlrenderer(data, **kwargs): # pylint: disable=unused-argument
     """Output as XML
 
     :param list data: Filename with properties

--- a/docmanager/display.py
+++ b/docmanager/display.py
@@ -33,7 +33,8 @@ def textrenderer(data, **kwargs): # pylint: disable=unused-argument
     if data is None:
         return
 
-    # print only the value of the given property if only one property and only one file are given
+    # print only the value of the given property if only one property and
+    # only one file are given
     if len(data) == 1:
         if len(data[0][1]) == 1:
             for v in data[0][1]:
@@ -43,7 +44,8 @@ def textrenderer(data, **kwargs): # pylint: disable=unused-argument
     # if there are more than one file or one property
     for d in data:
         props = d[1]
-        props = " ".join([ "%s=%s" % (key, value) for key, value in props.items()])
+        props = " ".join(["%s=%s" % (key, value) \
+                          for key, value in props.items()])
         if len(props):
             print("{} -> {}".format(d[0], props))
 

--- a/docmanager/logmanager.py
+++ b/docmanager/logmanager.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2014-2015 SUSE Linux GmbH
+# Copyright (c) 2015 SUSE Linux GmbH
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of version 3 of the GNU General Public License as

--- a/docmanager/table.py
+++ b/docmanager/table.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2014-2015 SUSE Linux GmbH
+# Copyright (c) 2015 SUSE Linux GmbH
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of version 3 of the GNU General Public License as

--- a/docmanager/xmlhandler.py
+++ b/docmanager/xmlhandler.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2014-2015 SUSE Linux GmbH
+# Copyright (c) 2015 SUSE Linux GmbH
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of version 3 of the GNU General Public License as
@@ -41,19 +41,19 @@ class XmlHandler(object):
         # general
         self._filename = ""
         self._buffer = None # StringIO
-        
+
         # prolog
         self._offset = 0
         self._header = ""
         self._root = ""
         self.roottag = ""
-        
+
         # parser
         self.__xmlparser = None
         self.invalidXML = False
         self.xmlErrorString = ""
         self.stopOnError = stopOnError
-        
+
         # lxml
         self.__tree = None
         self.__root = None
@@ -65,7 +65,7 @@ class XmlHandler(object):
 
         # log
         self.xmlLogErrorString = ""
-        
+
         # parse the given file with lxml
         self.parse()
 
@@ -73,7 +73,7 @@ class XmlHandler(object):
         """This function parses the whole XML file
         """
         logmgr_flog()
-        
+
         # find the prolog of the XML file (everything before the start tag)
         try:
             prolog = findprolog(self._buffer)
@@ -83,7 +83,7 @@ class XmlHandler(object):
                                       err.getColumnNumber(), \
                                       err.getMessage(), \
                                       self.filename,)
-            
+
             if self.stopOnError:
                 log.error(self.xmlLogErrorString)
                 sys.exit(ReturnCodes.E_XML_PARSE_ERROR)
@@ -94,20 +94,20 @@ class XmlHandler(object):
                 prolog['header'], \
                 prolog['root'], \
                 prolog['roottag']
-    
+
             # replace any entities
             self.replace_entities()
-    
+
             # register namespace
             # etree.register_namespace("dm", "{dm}".format(**NS))
             self.__xmlparser = etree.XMLParser(remove_blank_text=False,
                                                resolve_entities=False,
                                                dtd_validation=False)
-            
+
             # load the file and set a reference to the dm group
             self.__tree = etree.parse(self._buffer, self.__xmlparser)
             self.__root = self.__tree.getroot()
-            
+
             try:
                 check_root_element(self.__root, etree)
             except ValueError as err:
@@ -121,10 +121,10 @@ class XmlHandler(object):
             if not self.invalidXML:
                 # check for DocBook 5 namespace in start tag
                 self.check_docbook5_ns()
-                
+
                 # check for docmanager element
                 self.__docmanager = self.__tree.find("//dm:docmanager", namespaces=NS)
-                
+
                 if self.__docmanager is None:
                     log.info("No docmanager element found")
                     self.create_group()
@@ -139,28 +139,28 @@ class XmlHandler(object):
             log.error("{} is not a DocBook 5 XML document. The start tag of the document has to be in the official " \
                       "DocBook 5 namespace: {}".format(self._filename, NS['d']))
             sys.exit(ReturnCodes.E_NOT_DOCBOOK5_FILE)
-    
+
     def replace_entities(self):
         """This function replaces entities in the StringIO buffer
         """
         logmgr_flog()
-        
+
         self._buffer.seek(self._offset)
         self._buffer = replaceinstream(self._buffer, preserve_entities)
 
     def init_default_props(self, force=False, bugtracker=False):
         """Initializes the default properties for the given XML files
-    
+
         :param bool force: Ignore if there are already properties in an XML - just overwrite them
         """
         logmgr_flog()
 
         props = list(DefaultDocManagerProperties)
 
-        if bugtracker == True:
+        if bugtracker:
             for i in BugtrackerElementList:
                 props.append(i)
-        
+
         ret = 0
         for i in props:
             if (i not in self.get(i)) or \
@@ -174,7 +174,7 @@ class XmlHandler(object):
     def check_root_element(self):
         """Checks if root element is valid"""
         logmgr_flog()
-        
+
         tag = etree.QName(self.__root.tag)
         if tag.localname not in VALIDROOTS:
             raise ValueError("Cannot add info element to file '{}'. '{}' is not a valid root "
@@ -261,18 +261,18 @@ class XmlHandler(object):
     def is_prop_set(self, prop):
         """
         Checks if a property is set in an XML element
-        
+
         :param str prop: the property
-        
+
         :return: if property is set
         :rtype: bool
         """
         logmgr_flog()
-        
+
         element = self.__docmanager.find("./dm:{}".format(prop), namespaces=NS)
         if element is not None:
             return True
-        
+
         return False
 
     def get(self, keys=None):
@@ -290,7 +290,6 @@ class XmlHandler(object):
 
         dm = self.__docmanager
         dmelem = list()
-        lastnode = dm
         values = {}
 
         if not isinstance(keys, list):
@@ -310,12 +309,7 @@ class XmlHandler(object):
                 if node is None:
                     break
 
-                lastnode = node
-
-            if node is None:
-                values.update({ key: None })
-            else:
-                values.update({key: node.text})
+            values.update({key: None if node is None else node.text})
 
         return values
 
@@ -338,10 +332,10 @@ class XmlHandler(object):
         """
         logmgr_flog()
         key = key.split("/")
-        key = "/dm:".join(key)
-        key = "/dm:" + key
+        key = "dm:".join(key)
+        key = "dm:" + key
 
-        key_handler = self.__docmanager.find("." + key,
+        key_handler = self.__docmanager.find(key,
                                              namespaces=NS)
 
         if key_handler is not None:
@@ -369,7 +363,7 @@ class XmlHandler(object):
     def indent_dm(self):
         """Indents only dm:docmanager element and its children"""
         logmgr_flog()
-        
+
         dmindent='    '
         dm = self.__tree.find("//dm:docmanager",
                               namespaces=NS)
@@ -393,7 +387,6 @@ class XmlHandler(object):
         #log.info("prev: %s", prev)
         if prev is not None:
             log.info("prev: %s", prev)
-            previndent = "".join(prev.tail.split('\n'))
             prev.tail = '\n' + infoindent
         indent=self.get_indentation(dm.getprevious())
         dm.text = '\n' + indent + '    '
@@ -405,7 +398,7 @@ class XmlHandler(object):
     def write(self):
         """Write XML tree to original filename"""
         logmgr_flog()
-        
+
         # Only indent docmanager child elements
         self.indent_dm()
 

--- a/docmanager/xmlhandler.py
+++ b/docmanager/xmlhandler.py
@@ -20,9 +20,9 @@ import sys
 from docmanager.core import DefaultDocManagerProperties, \
      NS, ReturnCodes, VALIDROOTS, BugtrackerElementList
 from docmanager.logmanager import log, logmgr_flog
-from docmanager.xmlutil import check_root_element, compilestarttag, ensurefileobj, \
-     findprolog, get_namespace, localname, recover_entities, replaceinstream, preserve_entities, \
-     findinfo_pos, xml_indent
+from docmanager.xmlutil import check_root_element, compilestarttag, \
+     ensurefileobj, findprolog, get_namespace, localname, recover_entities, \
+     replaceinstream, preserve_entities, findinfo_pos, xml_indent
 from lxml import etree
 from xml.sax._exceptions import SAXParseException
 
@@ -36,7 +36,7 @@ class XmlHandler(object):
         :param str filename: filename of XML file
         """
         logmgr_flog()
-        log.debug("Initialized a new XML Handler for file '{}'.".format(filename))
+        log.debug("Initialized a new XML Handler for file %r.", filename)
 
         # general
         self._filename = ""
@@ -79,12 +79,13 @@ class XmlHandler(object):
             prolog = findprolog(self._buffer)
         except SAXParseException as err:
             self.invalidXML = True
-            self.xmlLogErrorString = "<{}:{}> {} in {!r}.".format(err.getLineNumber(), \
-                                      err.getColumnNumber(), \
-                                      err.getMessage(), \
-                                      self.filename,)
 
             if self.stopOnError:
+                self.xmlLogErrorString = "<{}:{}> {} in {!r}.".format(\
+                                            err.getLineNumber(), \
+                                            err.getColumnNumber(), \
+                                            err.getMessage(), \
+                                            self.filename,)
                 log.error(self.xmlLogErrorString)
                 sys.exit(ReturnCodes.E_XML_PARSE_ERROR)
 
@@ -129,15 +130,16 @@ class XmlHandler(object):
                     log.info("No docmanager element found")
                     self.create_group()
                 else:
-                    log.info("Found docmanager element %s", self.__docmanager.getparent() )
+                    log.info("Found docmanager element %s", self.__docmanager.getparent())
 
     def check_docbook5_ns(self):
         """Checks if the current file is a valid DocBook 5 file.
         """
         rootns = get_namespace(self.__root.tag)
         if rootns != NS['d']:
-            log.error("{} is not a DocBook 5 XML document. The start tag of the document has to be in the official " \
-                      "DocBook 5 namespace: {}".format(self._filename, NS['d']))
+            log.error("%s is not a DocBook 5 XML document. "
+                      "The start tag of the document has to be in the official "
+                      "DocBook 5 namespace: %s", self._filename, NS['d'])
             sys.exit(ReturnCodes.E_NOT_DOCBOOK5_FILE)
 
     def replace_entities(self):
@@ -151,7 +153,8 @@ class XmlHandler(object):
     def init_default_props(self, force=False, bugtracker=False):
         """Initializes the default properties for the given XML files
 
-        :param bool force: Ignore if there are already properties in an XML - just overwrite them
+        :param bool force: Ignore if there are already properties in an
+                           XML - just overwrite them
         """
         logmgr_flog()
 
@@ -177,8 +180,10 @@ class XmlHandler(object):
 
         tag = etree.QName(self.__root.tag)
         if tag.localname not in VALIDROOTS:
-            raise ValueError("Cannot add info element to file '{}'. '{}' is not a valid root "
-                             "element.".format(self._filename, localname(self.__root.tag)))
+            raise ValueError("Cannot add info element to file %r. "
+                             "This file does not contain a valid "
+                             "DocBook 5 root element. Found %s",
+                             self._filename, localname(self.__root.tag))
 
     def create_group(self):
         """Creates the docmanager group element"""
@@ -188,17 +193,17 @@ class XmlHandler(object):
         info = self.__tree.find("//d:info", namespaces=NS)
         # TODO: We need to check for a --force option
         if info is None:
-            log.info("No <info> element found!")
+            log.debug("No <info> element found!")
             pos = findinfo_pos(self.__root)
-            log.info("Using position %d", pos)
+            log.debug("Using position %d", pos)
             info = etree.Element("{%s}info" % NS["d"])
             info.tail = '\n'
             info.text = '\n'
             self.__root.insert(pos, info)
 
-            log.info("Adding <info> element in '%s'", self.filename)
+            log.debug("Adding <info> element in '%s'", self.filename)
 
-        log.info("Adding <dm:docmanager> to <info>")
+        log.debug("Adding <dm:docmanager> to <info>")
         # dm = etree.Element("{%s}docmanager" % NS["dm"])
         # self.__docmanager = info.insert(0, dm)
         self.__docmanager = etree.SubElement(info,

--- a/docmanager/xmlutil.py
+++ b/docmanager/xmlutil.py
@@ -153,7 +153,7 @@ def findinfo_pos(root):
     logmgr_flog()
 
     titles = root.xpath("(d:title|d:subtitle|d:titleabbrev)[last()]",
-                                namespaces=NS)
+                        namespaces=NS)
     if not titles:
         # Just in case we didn't find any titles at all, return null
         return 0
@@ -186,7 +186,7 @@ def ensurefileobj(source):
                 res = StringIO(open(source, 'r').read())
             # pylint: disable=undefined-variable
             except FileNotFoundError as err:
-                log.error("Could not find file '{}'.".format(err.filename))
+                log.error("Could not find file %r.", err.filename)
                 sys.exit(ReturnCodes.E_FILE_NOT_FOUND)
             # pylint: enable=undefined-variable
 

--- a/docmanager/xmlutil.py
+++ b/docmanager/xmlutil.py
@@ -43,7 +43,7 @@ def ent2txt(match, start="[[[", end="]]]"):
     :rtype: str
     """
     logmgr_flog()
-    
+
     if match:
         return "{}{}{}".format(start,
                                match.group(2),
@@ -58,7 +58,7 @@ def txt2ent(match):
     :rtype: str
     """
     logmgr_flog()
-    
+
     if match:
         return "&{};".format(match.group(2))
 
@@ -71,7 +71,7 @@ def preserve_entities(text):
     :rtype: str
     """
     logmgr_flog()
-    
+
     return ENTS.sub(ent2txt, text)
 
 
@@ -83,7 +83,7 @@ def recover_entities(text):
     :rtype: str
     """
     logmgr_flog()
-    
+
     return STEN.sub(txt2ent, text)
 
 
@@ -97,7 +97,7 @@ def replaceinstream(stream, func):
     :rtype: StringIO
     """
     logmgr_flog()
-    
+
     result = StringIO()
 
     for line in stream:
@@ -108,11 +108,11 @@ def replaceinstream(stream, func):
 
 def check_root_element(rootelem, etree):
     """Checks if root element is valid
-    
+
     :param object: root element (object)
     :param object: etree element (etree object)"""
     logmgr_flog()
-    
+
     tag = etree.QName(rootelem.tag)
     if tag.localname not in VALIDROOTS:
         raise ValueError("Cannot add info element to %s. "
@@ -128,7 +128,7 @@ def isXML(text):
        :rtype: bool
     """
     logmgr_flog()
-    
+
     possiblestartstrings = (re.compile("<\?xml"),
                             re.compile("<!DOCTYPE"),
                             re.compile("<!--",),
@@ -151,7 +151,7 @@ def findinfo_pos(root):
     :rtype: int
     """
     logmgr_flog()
-    
+
     titles = root.xpath("(d:title|d:subtitle|d:titleabbrev)[last()]",
                                 namespaces=NS)
     if not titles:
@@ -171,7 +171,7 @@ def ensurefileobj(source):
        :return: StringIO or file-like object
     """
     logmgr_flog()
-    
+
     # StringIO support:
     if hasattr(source, 'getvalue') and hasattr(source, 'tell'):
         # we return the source
@@ -184,10 +184,12 @@ def ensurefileobj(source):
             # so it has to be a filename
             try:
                 res = StringIO(open(source, 'r').read())
+            # pylint: disable=undefined-variable
             except FileNotFoundError as err:
                 log.error("Could not find file '{}'.".format(err.filename))
                 sys.exit(ReturnCodes.E_FILE_NOT_FOUND)
-            
+            # pylint: enable=undefined-variable
+
             return res
     # TODO: Check if source is an URL; should we allow this?
 
@@ -203,7 +205,7 @@ def localname(tag):
     :rtype:  str
     """
     logmgr_flog()
-    
+
     m = NAMESPACE_REGEX.search(tag)
     if m:
         return m.groupdict()['local']
@@ -218,7 +220,7 @@ def get_namespace(tag):
     :rtype:         str
     """
     logmgr_flog()
-    
+
     m = NAMESPACE_REGEX.search(tag)
     if m:
         return m.groupdict()['ns']
@@ -234,7 +236,7 @@ def compilestarttag(roottag=None):
        :rtype: _sre.SRE_Pattern
     """
     logmgr_flog()
-    
+
     # Taken from the xmllib.py
     # http://code.metager.de/source/xref/python/jython/lib-python/2.7/xmllib.py
     _S = '[ \t\r\n]+'                       # white space
@@ -262,7 +264,7 @@ class LocatingWrapper(object):
     """
     def __init__(self, f):
         logmgr_flog()
-        
+
         self.f = f
         self.offset = [0]
         self.curoffs = 0
@@ -270,7 +272,7 @@ class LocatingWrapper(object):
     def read(self, *a):
         """Read data"""
         logmgr_flog()
-        
+
         data = self.f.read(*a)
         self.offset.extend(accumulate(len(m)+1 for m in data.split('\n')))
         return data
@@ -283,7 +285,7 @@ class LocatingWrapper(object):
         :rtype:  int
         """
         logmgr_flog()
-        
+
         return self.offset[locator.getLineNumber() - 1] + locator.getColumnNumber()
 
     def close(self):
@@ -301,7 +303,7 @@ class Handler(xml.sax.handler.ContentHandler):
     """
     def __init__( self, context, locator):
         logmgr_flog()
-        
+
         # handler.ContentHandler.__init__( self )
         super().__init__()
         self.context = context
@@ -315,7 +317,7 @@ class Handler(xml.sax.handler.ContentHandler):
         :param LocatingWrapper loc: LocatingWrapper object
         """
         logmgr_flog()
-        
+
         self.loc = locator
 
     def startElement(self, name, attrs):
@@ -325,7 +327,7 @@ class Handler(xml.sax.handler.ContentHandler):
         :param Attributes attrs: attributes of the current element
         """
         logmgr_flog()
-        
+
         ctxlen = len(self.context)
         # We are only interested in the first two start tags
         if ctxlen < 2:
@@ -341,7 +343,7 @@ class Handler(xml.sax.handler.ContentHandler):
         :param str name:  XML 1.0 Name of the element
         """
         logmgr_flog()
-        
+
         eline = self.loc.getLineNumber()
         ecol = self.loc.getColumnNumber()
         last = self.locstm.where(self.loc)
@@ -358,7 +360,7 @@ class Handler(xml.sax.handler.ContentHandler):
         :param str data:   the data of the PI
         """
         logmgr_flog()
-        
+
         ctxlen = len(self.context)
         # Only append PIs when it's NOT before start-tag
         if ctxlen:
@@ -368,13 +370,13 @@ class Handler(xml.sax.handler.ContentHandler):
                             current)
             self.context.append(["?%s" % target, pos])
 
-    def comment(self, text): # pylint:unused-argument
+    def comment(self, text): # pylint: disable=unused-argument
         """Signals an XML comment
 
         :param str text: text content of the XML comment
         """
         logmgr_flog()
-        
+
         ctxlen = len(self.context)
         # We are only interested in the first two start tags
         if ctxlen:
@@ -391,7 +393,7 @@ class Handler(xml.sax.handler.ContentHandler):
 
     endCDATA = startCDATA
 
-    def startDTD(self,  doctype, publicID, systemID): # pylint:unused-argument
+    def startDTD(self,  doctype, publicID, systemID): # pylint:disable=unused-argument
         """Signals the start of an DTD declaration
 
         :param  doctype: name of the root element


### PR DESCRIPTION
- Fixed spaces in empty lines
- Disabled pylint warnings on some lines:
  unused-arguments and undefined-variable
- Corrected copyright year
- Removed unused variables
- Simplified comparisions with True or False
  <a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
  <a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
  <a href='https://www.codereviewhub.com/openSUSE/docmanager/pull/59?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/openSUSE/docmanager/pull/59'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
  <a href='#crh-end'></a>
