### PR TITLE
Fix problems with newer Python versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 # Config file for automatic testing at travis-ci.org
 language: python
 sudo: required
-python: "3.4"
+python: "3.6"
 env:
     global:
         - LD_PRELOAD=/lib/x86_64-linux-gnu/libSegFault.so
@@ -13,16 +13,14 @@ env:
 matrix:
   fast_finish: true
   include:
-    - python: 3.3
-      env: TOXENV=3.3
-    - python: 3.4
-      env: TOXENV=3.4
-    # Currently does not build :-(
-    #- python: 3.5
-    #  env: TOXENV=3.5
-    # - "nightly" currently points to 3.6-dev
-    #- python: nightly
-    #  env: TOXENV=3.6
+    - python: 3.6
+      env: TOXENV=py36
+    - python: 3.7
+      env: TOXENV=py37
+    - python: 3.8
+      env: TOXENV=py38
+    - python: 3.9
+      env: TOXENV=py39
 
 
 before_install:

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,29 +22,14 @@ default_section=THIRDPARTY
 max-line-length = 100
 exclude = test/*
 
-[pytest]
-norecursedirs =
-    __pycache__
-    .git
-    *.egg
-    .tox
-    .env
-    .tmp
-    build
-    dist
-    env
-    man
-python_files =
-    test_*.py
+[tool:pytest]
+norecursedirs =.git build .env/ env/ .pyenv/ .tmp/ .eggs/ venv/
+testpaths = test
 addopts =
     -rxEfsw
-    --strict
-    --ignore=test/conftest.py
-    --ignore=setup.py
-    --ignore=ci
-    --ignore=.env
-    --ignore=.tmp
-    --ignore=.eggs
+    --cov=docmanager
+    --no-cov-on-fail
+     --cov-report=term-missing
     --doctest-modules
 #    --doctest-glob=\*.rst
     --tb=long

--- a/src/docmanager/cli/checks.py
+++ b/src/docmanager/cli/checks.py
@@ -222,7 +222,7 @@ def input_format_check(args):
             sys.exit(ReturnCodes.E_WRONG_INPUT_FORMAT)
         except urllib.error.URLError as err:
             if hasattr(err, 'code') and err.code is not None:
-                if err.code is not 200:
+                if err.code != 200:
                     log.warn("The remote server returns an error code "
                              "for this request: {} - Please double check if "
                              "the URL is correct. Nevertheless the URL will "

--- a/test/test_docmanager_cli_del.py
+++ b/test/test_docmanager_cli_del.py
@@ -11,23 +11,23 @@ def test_docmanager_cli_del_0(tmp_valid_xml):
     """
 
     ustr = "Ehufuveva271"
-    file = tmp_valid_xml.strpath
+    xmlfile = tmp_valid_xml.strpath
 
-    prepare_file(file, ustr)
+    prepare_file(xmlfile, ustr)
     content = ""
 
-    with open(file, 'r') as f:
+    with open(xmlfile, 'r') as f:
         content = f.read()
     
     assert ustr in content
 
-    clicmd = "del -p {} {}".format(ustr, file)
+    clicmd = "del -p {} {}".format(ustr, xmlfile)
     a = Actions(parsecli(shlex.split(clicmd)))
     a.parse()
 
     content = ""
 
-    with open(file, 'r') as f:
+    with open(xmlfile, 'r') as f:
         content = f.read()
     
     assert ustr not in content

--- a/tox.ini
+++ b/tox.ini
@@ -1,20 +1,21 @@
 [tox]
 envlist =
     check,
-    3.3,
-    3.4,
-    3.5,
-    3.6,
-    docs
+    py{36,37,38,39}
+isolated_build = True
+
+[gh-actions]
+python =
+    3.6: py36
+    3.7: py37
+    3.8: py38
+    3.9: py39
+    # 3.10: py310
 
 
 [testenv]
-basepython =
-    3.3: python3.3
-    3.4: python3.4
-    3.5: python3.5
-    3.6: python3.6
-    {check,docs}: python3.4
+description = Run test suite for {basepython}
+# basepython = python3
 setenv =
     PYTHONPATH={toxinidir}/test
     PYTHONUNBUFFERED=yes
@@ -24,18 +25,20 @@ passenv =
 usedevelop = True
 deps =
     -r{toxinidir}/coverage_requirements.txt
-    pytest-travis-fold
+    # pytest-travis-fold
 commands =
-    py.test {posargs:-v --cov=docmanager --no-cov-on-fail}
+    pytest {posargs:-v}
 
 
 [testenv:docs]
+description = Build Man documentation
 changedir=man
 commands =
     make
 
 
 [testenv:check]
+description = Run code style checks
 deps =
     docutils
     check-manifest


### PR DESCRIPTION
This PR fixes mostly problems related to the `findprolog()` function:

Replace all the LocatingWrapper & Handler mostly with some code from getentity. It's maybe not 100% safe, but for the time being this is the quickest solution.


